### PR TITLE
fix: recreate DTLS stack on ICE restart via opt-in config flag

### DIFF
--- a/conf/janus.jcfg.sample.in
+++ b/conf/janus.jcfg.sample.in
@@ -302,6 +302,15 @@ nat: {
 	# by uncommenting the following property and set it to true
 	#hangup_on_failed = true
 
+	# When a peer's process is killed during an active call (e.g., app crash or OS
+	# kill) and reconnects via ICE restart (re-INVITE / UpdateRequest), the existing
+	# SSL* object in Janus rejects the fresh DTLS ClientHello as an RFC 5746
+	# renegotiation (verify_data mismatch), leaving DTLS stuck in connecting state
+	# and resulting in no audio after restoration. Enabling this option destroys and
+	# recreates the DTLS stack inside janus_ice_restart() so the new handshake
+	# completes successfully. Disabled by default (vanilla Janus behavior).
+	#dtls_recreate_on_ice_restart = false
+
 	# By default Janus tries to resolve mDNS (.local) candidates: even
 	# though this is now done asynchronously and shouldn't keep the API
 	# busy, even in case mDNS resolution takes a long time to timeout,

--- a/conf/janus.jcfg.sample.in
+++ b/conf/janus.jcfg.sample.in
@@ -302,13 +302,8 @@ nat: {
 	# by uncommenting the following property and set it to true
 	#hangup_on_failed = true
 
-	# When a peer's process is killed during an active call (e.g., app crash or OS
-	# kill) and reconnects via ICE restart (re-INVITE / UpdateRequest), the existing
-	# SSL* object in Janus rejects the fresh DTLS ClientHello as an RFC 5746
-	# renegotiation (verify_data mismatch), leaving DTLS stuck in connecting state
-	# and resulting in no audio after restoration. Enabling this option destroys and
-	# recreates the DTLS stack inside janus_ice_restart() so the new handshake
-	# completes successfully. Disabled by default (vanilla Janus behavior).
+	# Recreate the DTLS stack on ICE restart so a fresh ClientHello from a
+	# reconnecting peer is treated as a new handshake rather than renegotiation.
 	#dtls_recreate_on_ice_restart = false
 
 	# By default Janus tries to resolve mDNS (.local) candidates: even

--- a/src/ice.c
+++ b/src/ice.c
@@ -3873,10 +3873,38 @@ int janus_ice_setup_local(janus_ice_handle *handle, gboolean offer, gboolean tri
 void janus_ice_restart(janus_ice_handle *handle) {
 	if(!handle || !handle->agent || !handle->pc)
 		return;
+	janus_ice_peerconnection *pc = handle->pc;
 	/* Restart ICE */
 	if(nice_agent_restart(handle->agent) == FALSE) {
 		JANUS_LOG(LOG_WARN, "[%"SCNu64"] ICE restart failed...\n", handle->handle_id);
 	}
+	/* Recreate the DTLS context so a fresh ClientHello from the peer is treated as a new
+	 * handshake rather than RFC 5746 renegotiation. When the peer creates a new
+	 * RTCPeerConnection (e.g. after app restart), it sends a ClientHello with no
+	 * renegotiation_info. The existing connected SSL* rejects this with a fatal
+	 * handshake_failure alert, leaving DTLS stuck in connecting state. */
+	if(pc->dtlsrt_source != NULL) {
+		g_source_destroy(pc->dtlsrt_source);
+		g_source_unref(pc->dtlsrt_source);
+		pc->dtlsrt_source = NULL;
+	}
+	if(pc->dtls != NULL) {
+		janus_dtls_srtp_destroy(pc->dtls);
+		janus_refcount_decrease(&pc->dtls->ref);
+		pc->dtls = NULL;
+	}
+	pc->dtls = janus_dtls_srtp_create(pc, pc->dtls_role);
+	if(!pc->dtls) {
+		JANUS_LOG(LOG_ERR, "[%"SCNu64"] Error recreating DTLS-SRTP stack on ICE restart...\n", handle->handle_id);
+		janus_flags_clear(&handle->webrtc_flags, JANUS_ICE_HANDLE_WEBRTC_ICE_RESTART);
+		janus_ice_webrtc_hangup(handle, "DTLS-SRTP stack error on ICE restart");
+		return;
+	}
+	janus_refcount_increase(&pc->dtls->ref);
+	/* Reset pc->connected so the DTLS handshake is triggered again when ICE
+	 * reconnects. Without this, the guard in janus_ice_cb_nice_ready prevents
+	 * re-entering the handshake path after an ICE restart. */
+	pc->connected = 0;
 	janus_flags_clear(&handle->webrtc_flags, JANUS_ICE_HANDLE_WEBRTC_ICE_RESTART);
 }
 

--- a/src/ice.c
+++ b/src/ice.c
@@ -3913,11 +3913,12 @@ void janus_ice_restart(janus_ice_handle *handle) {
 		 * renegotiation_info. The existing connected SSL* rejects this with a fatal
 		 * handshake_failure alert, leaving DTLS stuck in connecting state.
 		 *
-		 * Hold handle->mutex for the entire destroy/create sequence, matching the pattern
-		 * used by janus_ice_webrtc_free(). This serializes against concurrent signaling-thread
-		 * operations (e.g. janus_ice_webrtc_hangup) that also acquire handle->mutex before
-		 * touching pc->dtls. */
-		janus_mutex_lock(&handle->mutex);
+		 * Note: janus_mutex is non-recursive. This function is called from two sites in
+		 * janus.c: one with handle->mutex already held (janus.c:1685) and one without
+		 * (janus.c:4091). We do NOT acquire the mutex here to avoid deadlocking the first
+		 * caller. The race with janus_ice_cb_nice_recv is mitigated by the refcount pattern
+		 * in that callback (see dtls_recreate_on_ice_restart guard there) and by the atomic
+		 * destroyed flag in janus_dtls_srtp_destroy(). */
 		if(pc->dtlsrt_source != NULL) {
 			g_source_destroy(pc->dtlsrt_source);
 			g_source_unref(pc->dtlsrt_source);
@@ -3931,7 +3932,6 @@ void janus_ice_restart(janus_ice_handle *handle) {
 		pc->dtls = janus_dtls_srtp_create(pc, pc->dtls_role);
 		if(!pc->dtls) {
 			JANUS_LOG(LOG_ERR, "[%"SCNu64"] Error recreating DTLS-SRTP stack on ICE restart...\n", handle->handle_id);
-			janus_mutex_unlock(&handle->mutex);
 			janus_flags_clear(&handle->webrtc_flags, JANUS_ICE_HANDLE_WEBRTC_ICE_RESTART);
 			janus_ice_webrtc_hangup(handle, "DTLS-SRTP stack error on ICE restart");
 			return;
@@ -3941,7 +3941,6 @@ void janus_ice_restart(janus_ice_handle *handle) {
 		 * reconnects. Without this, the guard in janus_ice_cb_nice_ready prevents
 		 * re-entering the handshake path after an ICE restart. */
 		pc->connected = 0;
-		janus_mutex_unlock(&handle->mutex);
 	}
 	janus_flags_clear(&handle->webrtc_flags, JANUS_ICE_HANDLE_WEBRTC_ICE_RESTART);
 }

--- a/src/ice.c
+++ b/src/ice.c
@@ -2607,20 +2607,7 @@ static void janus_ice_cb_nice_recv(NiceAgent *agent, guint stream_id, guint comp
 	if(janus_is_dtls(buf) || (!janus_is_rtp(buf, len) && !janus_is_rtcp(buf, len))) {
 		/* This is DTLS: either handshake stuff, or data coming from SCTP DataChannels */
 		JANUS_LOG(LOG_HUGE, "[%"SCNu64"] Looks like DTLS!\n", handle->handle_id);
-		/* When dtls_recreate_on_ice_restart is enabled, take a short-lived reference on
-		 * pc->dtls before calling into it. janus_ice_restart() may destroy and recreate
-		 * pc->dtls on the signaling thread; holding a reference prevents the memory from
-		 * being freed while janus_dtls_srtp_incoming_msg() is still executing. */
-		if(dtls_recreate_on_ice_restart) {
-			janus_dtls_srtp *dtls = pc->dtls;
-			if(dtls) {
-				janus_refcount_increase(&dtls->ref);
-				janus_dtls_srtp_incoming_msg(dtls, buf, len);
-				janus_refcount_decrease(&dtls->ref);
-			}
-		} else {
-			janus_dtls_srtp_incoming_msg(pc->dtls, buf, len);
-		}
+		janus_dtls_srtp_incoming_msg(pc->dtls, buf, len);
 		/* Update stats (TODO Do the same for the last second window as well) */
 		pc->dtls_in_stats.info[0].packets++;
 		pc->dtls_in_stats.info[0].bytes += len;
@@ -3898,49 +3885,69 @@ int janus_ice_setup_local(janus_ice_handle *handle, gboolean offer, gboolean tri
 	return 0;
 }
 
+/* GDestroyNotify wrapper for janus_refcount_decrease, which is a macro and
+ * cannot be used directly as a function pointer. */
+static void janus_ice_dtls_recreate_unref(gpointer handle_ptr) {
+	janus_ice_handle *handle = (janus_ice_handle *)handle_ptr;
+	janus_refcount_decrease(&handle->ref);
+}
+
+/* Idle source callback: runs on the handle's GLib main loop, serialized with
+ * janus_ice_cb_nice_recv. Destroys the old DTLS stack and creates a fresh one
+ * so that a new ClientHello from the peer (e.g. after app restart) is accepted
+ * as a new handshake rather than rejected as RFC 5746 renegotiation. */
+static gboolean janus_ice_dtls_recreate_cb(gpointer user_data) {
+	janus_ice_handle *handle = (janus_ice_handle *)user_data;
+	if(!handle || !handle->pc ||
+			janus_flags_is_set(&handle->webrtc_flags, JANUS_ICE_HANDLE_WEBRTC_STOP)) {
+		return G_SOURCE_REMOVE;
+	}
+	janus_ice_peerconnection *pc = handle->pc;
+	JANUS_LOG(LOG_INFO, "[%"SCNu64"] Recreating DTLS stack after ICE restart\n", handle->handle_id);
+	if(pc->dtlsrt_source != NULL) {
+		g_source_destroy(pc->dtlsrt_source);
+		g_source_unref(pc->dtlsrt_source);
+		pc->dtlsrt_source = NULL;
+	}
+	if(pc->dtls != NULL) {
+		janus_dtls_srtp_destroy(pc->dtls);
+		janus_refcount_decrease(&pc->dtls->ref);
+		pc->dtls = NULL;
+	}
+	pc->dtls = janus_dtls_srtp_create(pc, pc->dtls_role);
+	if(!pc->dtls) {
+		JANUS_LOG(LOG_ERR, "[%"SCNu64"] Error recreating DTLS-SRTP stack on ICE restart...\n", handle->handle_id);
+		janus_ice_webrtc_hangup(handle, "DTLS-SRTP stack error on ICE restart");
+		return G_SOURCE_REMOVE;
+	}
+	janus_refcount_increase(&pc->dtls->ref);
+	/* Reset pc->connected so the DTLS handshake fires again when ICE reconnects.
+	 * Without this, the guard in janus_ice_cb_nice_ready skips the handshake path. */
+	pc->connected = 0;
+	janus_flags_clear(&handle->webrtc_flags, JANUS_ICE_HANDLE_WEBRTC_ICE_RESTART);
+	return G_SOURCE_REMOVE;
+}
+
 void janus_ice_restart(janus_ice_handle *handle) {
 	if(!handle || !handle->agent || !handle->pc)
 		return;
-	janus_ice_peerconnection *pc = handle->pc;
 	/* Restart ICE */
 	if(nice_agent_restart(handle->agent) == FALSE) {
 		JANUS_LOG(LOG_WARN, "[%"SCNu64"] ICE restart failed...\n", handle->handle_id);
 	}
 	if(dtls_recreate_on_ice_restart) {
-		/* Recreate the DTLS context so a fresh ClientHello from the peer is treated as a new
-		 * handshake rather than RFC 5746 renegotiation. When the peer creates a new
-		 * RTCPeerConnection (e.g. after app restart), it sends a ClientHello with no
-		 * renegotiation_info. The existing connected SSL* rejects this with a fatal
-		 * handshake_failure alert, leaving DTLS stuck in connecting state.
-		 *
-		 * Note: janus_mutex is non-recursive. This function is called from two sites in
-		 * janus.c: one with handle->mutex already held (janus.c:1685) and one without
-		 * (janus.c:4091). We do NOT acquire the mutex here to avoid deadlocking the first
-		 * caller. The race with janus_ice_cb_nice_recv is mitigated by the refcount pattern
-		 * in that callback (see dtls_recreate_on_ice_restart guard there) and by the atomic
-		 * destroyed flag in janus_dtls_srtp_destroy(). */
-		if(pc->dtlsrt_source != NULL) {
-			g_source_destroy(pc->dtlsrt_source);
-			g_source_unref(pc->dtlsrt_source);
-			pc->dtlsrt_source = NULL;
-		}
-		if(pc->dtls != NULL) {
-			janus_dtls_srtp_destroy(pc->dtls);
-			janus_refcount_decrease(&pc->dtls->ref);
-			pc->dtls = NULL;
-		}
-		pc->dtls = janus_dtls_srtp_create(pc, pc->dtls_role);
-		if(!pc->dtls) {
-			JANUS_LOG(LOG_ERR, "[%"SCNu64"] Error recreating DTLS-SRTP stack on ICE restart...\n", handle->handle_id);
-			janus_flags_clear(&handle->webrtc_flags, JANUS_ICE_HANDLE_WEBRTC_ICE_RESTART);
-			janus_ice_webrtc_hangup(handle, "DTLS-SRTP stack error on ICE restart");
-			return;
-		}
-		janus_refcount_increase(&pc->dtls->ref);
-		/* Reset pc->connected so the DTLS handshake is triggered again when ICE
-		 * reconnects. Without this, the guard in janus_ice_cb_nice_ready prevents
-		 * re-entering the handshake path after an ICE restart. */
-		pc->connected = 0;
+		/* Schedule DTLS destroy/create on the handle's GLib main loop.
+		 * janus_ice_cb_nice_recv also runs on this loop, so the two operations
+		 * are serialized by the event loop dispatcher — no mutex needed and
+		 * no pointer/refcount race between the threads. The ICE_RESTART flag
+		 * is cleared inside the callback once the new stack is ready. */
+		janus_refcount_increase(&handle->ref);
+		GSource *idle_source = g_idle_source_new();
+		g_source_set_callback(idle_source, janus_ice_dtls_recreate_cb, handle,
+				janus_ice_dtls_recreate_unref);
+		g_source_attach(idle_source, handle->mainctx);
+		g_source_unref(idle_source);
+		return;
 	}
 	janus_flags_clear(&handle->webrtc_flags, JANUS_ICE_HANDLE_WEBRTC_ICE_RESTART);
 }

--- a/src/ice.c
+++ b/src/ice.c
@@ -187,6 +187,21 @@ gboolean janus_ice_is_hangup_on_failed_enabled(void) {
 	return janus_ice_hangup_on_failed;
 }
 
+/* Whether to recreate the DTLS stack on ICE restart. When a peer's process is killed
+ * during an active call and reconnects via ICE restart, the existing SSL* object rejects
+ * the fresh ClientHello as an RFC 5746 renegotiation, leaving DTLS stuck. Enabling this
+ * destroys and recreates the DTLS stack on ICE restart so the new handshake completes. */
+static gboolean dtls_recreate_on_ice_restart = FALSE;
+void janus_ice_set_dtls_recreate_on_ice_restart_enabled(gboolean enabled) {
+	dtls_recreate_on_ice_restart = enabled;
+	if(dtls_recreate_on_ice_restart) {
+		JANUS_LOG(LOG_INFO, "Will recreate DTLS stack on ICE restart\n");
+	}
+}
+gboolean janus_ice_is_dtls_recreate_on_ice_restart_enabled(void) {
+	return dtls_recreate_on_ice_restart;
+}
+
 /* Opaque IDs set by applications are by default only passed to event handlers
  * for correlation purposes, but not sent back to the user or application in
  * the related Janus API responses or events, unless configured otherwise */
@@ -2592,7 +2607,20 @@ static void janus_ice_cb_nice_recv(NiceAgent *agent, guint stream_id, guint comp
 	if(janus_is_dtls(buf) || (!janus_is_rtp(buf, len) && !janus_is_rtcp(buf, len))) {
 		/* This is DTLS: either handshake stuff, or data coming from SCTP DataChannels */
 		JANUS_LOG(LOG_HUGE, "[%"SCNu64"] Looks like DTLS!\n", handle->handle_id);
-		janus_dtls_srtp_incoming_msg(pc->dtls, buf, len);
+		/* When dtls_recreate_on_ice_restart is enabled, take a short-lived reference on
+		 * pc->dtls before calling into it. janus_ice_restart() may destroy and recreate
+		 * pc->dtls on the signaling thread; holding a reference prevents the memory from
+		 * being freed while janus_dtls_srtp_incoming_msg() is still executing. */
+		if(dtls_recreate_on_ice_restart) {
+			janus_dtls_srtp *dtls = pc->dtls;
+			if(dtls) {
+				janus_refcount_increase(&dtls->ref);
+				janus_dtls_srtp_incoming_msg(dtls, buf, len);
+				janus_refcount_decrease(&dtls->ref);
+			}
+		} else {
+			janus_dtls_srtp_incoming_msg(pc->dtls, buf, len);
+		}
 		/* Update stats (TODO Do the same for the last second window as well) */
 		pc->dtls_in_stats.info[0].packets++;
 		pc->dtls_in_stats.info[0].bytes += len;
@@ -3878,33 +3906,43 @@ void janus_ice_restart(janus_ice_handle *handle) {
 	if(nice_agent_restart(handle->agent) == FALSE) {
 		JANUS_LOG(LOG_WARN, "[%"SCNu64"] ICE restart failed...\n", handle->handle_id);
 	}
-	/* Recreate the DTLS context so a fresh ClientHello from the peer is treated as a new
-	 * handshake rather than RFC 5746 renegotiation. When the peer creates a new
-	 * RTCPeerConnection (e.g. after app restart), it sends a ClientHello with no
-	 * renegotiation_info. The existing connected SSL* rejects this with a fatal
-	 * handshake_failure alert, leaving DTLS stuck in connecting state. */
-	if(pc->dtlsrt_source != NULL) {
-		g_source_destroy(pc->dtlsrt_source);
-		g_source_unref(pc->dtlsrt_source);
-		pc->dtlsrt_source = NULL;
+	if(dtls_recreate_on_ice_restart) {
+		/* Recreate the DTLS context so a fresh ClientHello from the peer is treated as a new
+		 * handshake rather than RFC 5746 renegotiation. When the peer creates a new
+		 * RTCPeerConnection (e.g. after app restart), it sends a ClientHello with no
+		 * renegotiation_info. The existing connected SSL* rejects this with a fatal
+		 * handshake_failure alert, leaving DTLS stuck in connecting state.
+		 *
+		 * Hold handle->mutex for the entire destroy/create sequence, matching the pattern
+		 * used by janus_ice_webrtc_free(). This serializes against concurrent signaling-thread
+		 * operations (e.g. janus_ice_webrtc_hangup) that also acquire handle->mutex before
+		 * touching pc->dtls. */
+		janus_mutex_lock(&handle->mutex);
+		if(pc->dtlsrt_source != NULL) {
+			g_source_destroy(pc->dtlsrt_source);
+			g_source_unref(pc->dtlsrt_source);
+			pc->dtlsrt_source = NULL;
+		}
+		if(pc->dtls != NULL) {
+			janus_dtls_srtp_destroy(pc->dtls);
+			janus_refcount_decrease(&pc->dtls->ref);
+			pc->dtls = NULL;
+		}
+		pc->dtls = janus_dtls_srtp_create(pc, pc->dtls_role);
+		if(!pc->dtls) {
+			JANUS_LOG(LOG_ERR, "[%"SCNu64"] Error recreating DTLS-SRTP stack on ICE restart...\n", handle->handle_id);
+			janus_mutex_unlock(&handle->mutex);
+			janus_flags_clear(&handle->webrtc_flags, JANUS_ICE_HANDLE_WEBRTC_ICE_RESTART);
+			janus_ice_webrtc_hangup(handle, "DTLS-SRTP stack error on ICE restart");
+			return;
+		}
+		janus_refcount_increase(&pc->dtls->ref);
+		/* Reset pc->connected so the DTLS handshake is triggered again when ICE
+		 * reconnects. Without this, the guard in janus_ice_cb_nice_ready prevents
+		 * re-entering the handshake path after an ICE restart. */
+		pc->connected = 0;
+		janus_mutex_unlock(&handle->mutex);
 	}
-	if(pc->dtls != NULL) {
-		janus_dtls_srtp_destroy(pc->dtls);
-		janus_refcount_decrease(&pc->dtls->ref);
-		pc->dtls = NULL;
-	}
-	pc->dtls = janus_dtls_srtp_create(pc, pc->dtls_role);
-	if(!pc->dtls) {
-		JANUS_LOG(LOG_ERR, "[%"SCNu64"] Error recreating DTLS-SRTP stack on ICE restart...\n", handle->handle_id);
-		janus_flags_clear(&handle->webrtc_flags, JANUS_ICE_HANDLE_WEBRTC_ICE_RESTART);
-		janus_ice_webrtc_hangup(handle, "DTLS-SRTP stack error on ICE restart");
-		return;
-	}
-	janus_refcount_increase(&pc->dtls->ref);
-	/* Reset pc->connected so the DTLS handshake is triggered again when ICE
-	 * reconnects. Without this, the guard in janus_ice_cb_nice_ready prevents
-	 * re-entering the handshake path after an ICE restart. */
-	pc->connected = 0;
 	janus_flags_clear(&handle->webrtc_flags, JANUS_ICE_HANDLE_WEBRTC_ICE_RESTART);
 }
 

--- a/src/ice.c
+++ b/src/ice.c
@@ -192,6 +192,7 @@ gboolean janus_ice_is_hangup_on_failed_enabled(void) {
  * the fresh ClientHello as an RFC 5746 renegotiation, leaving DTLS stuck. Enabling this
  * destroys and recreates the DTLS stack on ICE restart so the new handshake completes. */
 static gboolean dtls_recreate_on_ice_restart = FALSE;
+
 void janus_ice_set_dtls_recreate_on_ice_restart_enabled(gboolean enabled) {
 	dtls_recreate_on_ice_restart = enabled;
 	if(dtls_recreate_on_ice_restart) {
@@ -3895,14 +3896,21 @@ static void janus_ice_dtls_recreate_unref(gpointer handle_ptr) {
 /* Idle source callback: runs on the handle's GLib main loop, serialized with
  * janus_ice_cb_nice_recv. Destroys the old DTLS stack and creates a fresh one
  * so that a new ClientHello from the peer (e.g. after app restart) is accepted
- * as a new handshake rather than rejected as RFC 5746 renegotiation. */
+ * as a new handshake rather than rejected as RFC 5746 renegotiation.
+ * After this callback completes, wait for janus_ice_cb_nice_ready to trigger
+ * the new DTLS handshake once ICE reconnects. */
 static gboolean janus_ice_dtls_recreate_cb(gpointer user_data) {
 	janus_ice_handle *handle = (janus_ice_handle *)user_data;
-	if(!handle || !handle->pc ||
-			janus_flags_is_set(&handle->webrtc_flags, JANUS_ICE_HANDLE_WEBRTC_STOP)) {
+	if(!handle || janus_flags_is_set(&handle->webrtc_flags, JANUS_ICE_HANDLE_WEBRTC_STOP))
+		return G_SOURCE_REMOVE;
+	/* Hold handle->mutex while touching pc->dtls, matching the pattern used by
+	 * janus_ice_webrtc_free() which sets handle->pc = NULL under the same lock. */
+	janus_mutex_lock(&handle->mutex);
+	janus_ice_peerconnection *pc = handle->pc;
+	if(!pc) {
+		janus_mutex_unlock(&handle->mutex);
 		return G_SOURCE_REMOVE;
 	}
-	janus_ice_peerconnection *pc = handle->pc;
 	JANUS_LOG(LOG_INFO, "[%"SCNu64"] Recreating DTLS stack after ICE restart\n", handle->handle_id);
 	if(pc->dtlsrt_source != NULL) {
 		g_source_destroy(pc->dtlsrt_source);
@@ -3917,6 +3925,7 @@ static gboolean janus_ice_dtls_recreate_cb(gpointer user_data) {
 	pc->dtls = janus_dtls_srtp_create(pc, pc->dtls_role);
 	if(!pc->dtls) {
 		JANUS_LOG(LOG_ERR, "[%"SCNu64"] Error recreating DTLS-SRTP stack on ICE restart...\n", handle->handle_id);
+		janus_mutex_unlock(&handle->mutex);
 		janus_ice_webrtc_hangup(handle, "DTLS-SRTP stack error on ICE restart");
 		return G_SOURCE_REMOVE;
 	}
@@ -3924,7 +3933,7 @@ static gboolean janus_ice_dtls_recreate_cb(gpointer user_data) {
 	/* Reset pc->connected so the DTLS handshake fires again when ICE reconnects.
 	 * Without this, the guard in janus_ice_cb_nice_ready skips the handshake path. */
 	pc->connected = 0;
-	janus_flags_clear(&handle->webrtc_flags, JANUS_ICE_HANDLE_WEBRTC_ICE_RESTART);
+	janus_mutex_unlock(&handle->mutex);
 	return G_SOURCE_REMOVE;
 }
 
@@ -3935,21 +3944,19 @@ void janus_ice_restart(janus_ice_handle *handle) {
 	if(nice_agent_restart(handle->agent) == FALSE) {
 		JANUS_LOG(LOG_WARN, "[%"SCNu64"] ICE restart failed...\n", handle->handle_id);
 	}
+	/* Clear the restart flag now: it signals "restart was requested", not "DTLS is ready". */
+	janus_flags_clear(&handle->webrtc_flags, JANUS_ICE_HANDLE_WEBRTC_ICE_RESTART);
 	if(dtls_recreate_on_ice_restart) {
 		/* Schedule DTLS destroy/create on the handle's GLib main loop.
 		 * janus_ice_cb_nice_recv also runs on this loop, so the two operations
-		 * are serialized by the event loop dispatcher — no mutex needed and
-		 * no pointer/refcount race between the threads. The ICE_RESTART flag
-		 * is cleared inside the callback once the new stack is ready. */
+		 * are serialized by the event loop dispatcher — no concurrent access to pc->dtls. */
 		janus_refcount_increase(&handle->ref);
 		GSource *idle_source = g_idle_source_new();
 		g_source_set_callback(idle_source, janus_ice_dtls_recreate_cb, handle,
 				janus_ice_dtls_recreate_unref);
 		g_source_attach(idle_source, handle->mainctx);
 		g_source_unref(idle_source);
-		return;
 	}
-	janus_flags_clear(&handle->webrtc_flags, JANUS_ICE_HANDLE_WEBRTC_ICE_RESTART);
 }
 
 void janus_ice_resend_trickles(janus_ice_handle *handle) {

--- a/src/ice.h
+++ b/src/ice.h
@@ -174,6 +174,12 @@ void janus_ice_set_hangup_on_failed_enabled(gboolean enabled);
 /*! \brief Method to check whether ICE failures will result in immediate hangups
  * @returns true if enabled, false (default) otherwise */
 gboolean janus_ice_is_hangup_on_failed_enabled(void);
+/*! \brief Method to enable/disable DTLS recreation on ICE restart
+ * @param[in] enabled Whether DTLS should be recreated on ICE restart */
+void janus_ice_set_dtls_recreate_on_ice_restart_enabled(gboolean enabled);
+/*! \brief Method to check whether DTLS recreation on ICE restart is enabled
+ * @returns true if enabled, false (default) otherwise */
+gboolean janus_ice_is_dtls_recreate_on_ice_restart_enabled(void);
 /*! \brief Method to modify the min NACK value (i.e., the minimum time window of packets per handle to store for retransmissions)
  * @param[in] mnq The new min NACK value */
 void janus_set_min_nack_queue(uint16_t mnq);

--- a/src/janus.c
+++ b/src/janus.c
@@ -5269,6 +5269,9 @@ gint main(int argc, char *argv[]) {
 	item = janus_config_get(config, config_nat, janus_config_type_item, "hangup_on_failed");
 	if(item && item->value)
 		janus_ice_set_hangup_on_failed_enabled(janus_is_true(item->value));
+	item = janus_config_get(config, config_nat, janus_config_type_item, "dtls_recreate_on_ice_restart");
+	if(item && item->value)
+		janus_ice_set_dtls_recreate_on_ice_restart_enabled(janus_is_true(item->value));
 	if(janus_ice_set_turn_server(turn_server, turn_port, turn_type, turn_user, turn_pwd) < 0) {
 		if(!ignore_unreachable_ice_server) {
 			JANUS_LOG(LOG_FATAL, "Invalid TURN address %s:%u\n", turn_server, turn_port);


### PR DESCRIPTION
## Problem

When a peer creates a new \`RTCPeerConnection\` after an app restart (process kill), it sends a fresh DTLS \`ClientHello\` with no \`renegotiation_info\` extension. The existing connected \`SSL*\` object in Janus interprets this as an RFC 5746 renegotiation attempt and rejects it — because \`renegotiated_connection\` does not match the previous \`verify_data\`. DTLS stays stuck in \`connecting\` state, resulting in **no audio after call restoration**.

Additionally, \`pc->connected\` is never reset, so even with a new DTLS object the guard in \`janus_ice_cb_nice_ready()\` prevents the handshake from being re-entered after ICE reconnects.

Affects any scenario where the peer's process is killed mid-call and reconnects via ICE restart (re-INVITE / UpdateRequest).

## Fix

Introduces an opt-in config flag \`dtls_recreate_on_ice_restart\` (default: \`false\`, vanilla Janus behavior unchanged).

When enabled, \`janus_ice_restart()\` schedules DTLS recreation as a GLib idle source on the handle's \`mainctx\` instead of doing it inline. This is the key design choice:

- \`janus_ice_cb_nice_recv\` runs on the same GLib main loop
- Scheduling via \`g_idle_source_new()\` + \`g_source_attach(handle->mainctx)\` serializes the destroy/create with any in-flight receive callbacks — no mutex on \`pc->dtls\`, no race
- \`handle->mutex\` is held inside the callback when touching \`handle->pc\`, matching the pattern in \`janus_ice_webrtc_free()\`
- \`janus_refcount_increase/decrease\` on the handle guards against the handle being freed before the idle fires (via \`GDestroyNotify\`)
- \`JANUS_ICE_HANDLE_WEBRTC_ICE_RESTART\` is cleared in \`janus_ice_restart()\` immediately after \`nice_agent_restart()\` — not in the callback — since the flag means "restart was requested", not "DTLS is ready"

After the idle callback recreates the DTLS stack and resets \`pc->connected = 0\`, \`janus_ice_cb_nice_ready()\` re-enters the handshake path once ICE reconnects.

## Changes

- \`src/ice.c\` — \`janus_ice_restart()\`, \`janus_ice_dtls_recreate_cb()\`, global flag + accessors
- \`src/ice.h\` — declarations for the two new accessors
- \`src/janus.c\` — read \`dtls_recreate_on_ice_restart\` from \`[nat]\` config section
- \`conf/janus.jcfg.sample.in\` — document the new option

## Test

Tested on local WebTrit stack (Android device, app killed by OS mid-call):

```
[6086181492219027] ICE restart detected
[6086181492219027] Recreating DTLS stack after ICE restart
[6086181492219027]   Component is ready enough, starting DTLS handshake...
[6086181492219027] DTLS established, yay!
[6086181492219027] The DTLS handshake for the component 1 in stream 1 has been completed
```

Without this fix: DTLS stuck at \`connecting\`, zero audio after restoration.

## Relation to upstream stance

Janus upstream recommends "create a new handle" for reconnection (issue #3021). This patch achieves the same effect — a fresh \`SSL*\` — within the existing handle so the SIP dialog with the proxy is preserved and call restoration is transparent to the user. The flag is disabled by default so existing deployments are unaffected.

## Investigation

Full root cause analysis and test history: https://youtrack.portaone.com/issue/WT-1299