### PR TITLE
fix(ice): skip DTLS recreate on ICE restart when peer fingerprint unchanged (WT-1540)

### DIFF
--- a/src/ice.c
+++ b/src/ice.c
@@ -3917,6 +3917,17 @@ void janus_ice_restart(janus_ice_handle *handle) {
 	/* Clear the restart flag now: it signals "restart was requested", not "DTLS is ready". */
 	janus_flags_clear(&handle->webrtc_flags, JANUS_ICE_HANDLE_WEBRTC_ICE_RESTART);
 	if(dtls_recreate_on_ice_restart) {
+		/* Skip DTLS recreate when the peer's certificate did not change. A plain ICE
+		 * restart (network handover on the same PeerConnection) keeps the same SSL*
+		 * context valid over the new candidate pair; recreating here would force a
+		 * fresh ClientHello that the peer's still-active DTLS server would reject as
+		 * an RFC 5746 renegotiation, breaking media. */
+		if(!janus_flags_is_set(&handle->webrtc_flags, JANUS_ICE_HANDLE_WEBRTC_DTLS_FINGERPRINT_CHANGED)) {
+			JANUS_LOG(LOG_INFO, "[%"SCNu64"] DTLS fingerprint unchanged on ICE restart, keeping existing stack\n",
+				handle->handle_id);
+			return;
+		}
+		janus_flags_clear(&handle->webrtc_flags, JANUS_ICE_HANDLE_WEBRTC_DTLS_FINGERPRINT_CHANGED);
 		/* Schedule DTLS destroy/create on the handle's GLib main loop.
 		 * janus_ice_cb_nice_recv also runs on this loop, so the two operations
 		 * are serialized by the event loop dispatcher — no concurrent access to pc->dtls. */

--- a/src/ice.h
+++ b/src/ice.h
@@ -280,6 +280,7 @@ typedef struct janus_ice_trickle janus_ice_trickle;
 #define JANUS_ICE_HANDLE_WEBRTC_RFC4588_RTX			(1 << 19)
 #define JANUS_ICE_HANDLE_WEBRTC_NEW_DATACHAN_SDP	(1 << 20)
 #define JANUS_ICE_HANDLE_WEBRTC_E2EE				(1 << 21)
+#define JANUS_ICE_HANDLE_WEBRTC_DTLS_FINGERPRINT_CHANGED	(1 << 22)
 
 
 /*! \brief Janus media types */

--- a/src/sdp.c
+++ b/src/sdp.c
@@ -409,6 +409,18 @@ int janus_sdp_process_remote(void *ice_handle, janus_sdp *remote_sdp, gboolean r
 				JANUS_LOG(LOG_INFO, "[%"SCNu64"] ICE restart detected\n", handle->handle_id);
 				janus_flags_clear(&handle->webrtc_flags, JANUS_ICE_HANDLE_WEBRTC_ALL_TRICKLES);
 				janus_flags_set(&handle->webrtc_flags, JANUS_ICE_HANDLE_WEBRTC_ICE_RESTART);
+				/* Record whether the peer's DTLS fingerprint changed too. A plain ICE
+				 * restart on the same PeerConnection (e.g. network handover) keeps the
+				 * same cert; a fresh PeerConnection (e.g. after process kill) brings a
+				 * new one. The DTLS-recreate path uses this to decide whether to throw
+				 * away the still-working SSL* context. */
+				if(janus_is_webrtc_encryption_enabled() && rfingerprint != NULL &&
+						pc->remote_fingerprint != NULL &&
+						g_strcmp0(pc->remote_fingerprint, rfingerprint) != 0) {
+					janus_flags_set(&handle->webrtc_flags, JANUS_ICE_HANDLE_WEBRTC_DTLS_FINGERPRINT_CHANGED);
+				} else {
+					janus_flags_clear(&handle->webrtc_flags, JANUS_ICE_HANDLE_WEBRTC_DTLS_FINGERPRINT_CHANGED);
+				}
 			}
 			/* Store fingerprint and hashing */
 			if(janus_is_webrtc_encryption_enabled()) {


### PR DESCRIPTION
## Summary

Follow-up to #9. When `dtls_recreate_on_ice_restart=true` is set, `janus_ice_restart()` currently tears down the DTLS stack on **every** ICE restart, even when the peer keeps the same `PeerConnection` and the same DTLS certificate (typical Wi-Fi handover). The peer never initiates a fresh handshake against the new server-side `SSL*` -> 20s DTLS timeout -> call drops.

This PR makes the recreate conditional on the peer's `a=fingerprint` actually changing between the previous and the current remote SDP.

- **Plain ICE restart** (same cert) -> keeps the existing `SSL*` (no media interruption beyond the few seconds of ICE re-checks).
- **Restoration after force-stop / process kill** (new cert) -> still triggers the original recreate path -> WT-1299 continues to work.

## Change

- `src/ice.h` - new flag `JANUS_ICE_HANDLE_WEBRTC_DTLS_FINGERPRINT_CHANGED (1 << 22)`
- `src/sdp.c` - in `janus_sdp_process_remote()`, inside the existing ICE-restart detection block, set/clear the new flag by comparing `rfingerprint` with the cached `pc->remote_fingerprint`
- `src/ice.c` - in `janus_ice_restart()`, before the recreate path, check the flag; if not set, log `"DTLS fingerprint unchanged on ICE restart, keeping existing stack"` and return early. Flag is cleared in either branch.

Net: +24 lines across 3 files, no behaviour change when `dtls_recreate_on_ice_restart=false` (production default).

## Test plan

Verified locally with `dtls_recreate_on_ice_restart=true` against a Janus + Asterisk setup:

- [x] **CASE A - Wi-Fi off/on, app live:** with the flag enabled and this patch applied, ICE restart fires, log shows `"DTLS fingerprint unchanged on ICE restart, keeping existing stack"`, no recreate, no 20s timeout, audio resumes in ~3s.
- [x] **CASE A baseline (`=false`):** unchanged behaviour (no recreate, no patch interaction).
- [x] **CASE B - Force-stop + restore:** this PR does **not** close this case - the failure is on the SDP/mid-handling layer (peer offer arrives with `mid:2`/`mid:3` and Janus answer with `mid:0` rejected by libwebrtc). Tracked separately. Patch correctly recreates DTLS when peer fingerprint differs; further handshake never starts due to higher-layer mismatch.

## References

- WT-1540 - root issue (broader, this PR closes one of the contributing factors)
- WT-1299 - original reason the `dtls_recreate_on_ice_restart` flag was introduced (#9)