### PR TITLE
chore(ice): default dtls_recreate_on_ice_restart to TRUE (WT-1540)

### DIFF
--- a/conf/janus.jcfg.sample.in
+++ b/conf/janus.jcfg.sample.in
@@ -307,7 +307,13 @@ nat: {
 
 	# Recreate the DTLS stack on ICE restart so a fresh ClientHello from a
 	# reconnecting peer is treated as a new handshake rather than renegotiation.
-	#dtls_recreate_on_ice_restart = false
+	# Default ON: the recreate is now skipped automatically when the peer's
+	# a=fingerprint did not change between the previous and the current remote
+	# SDP (i.e. plain ICE restart on the same PeerConnection keeps the existing
+	# SSL* alive). Only a true peer-cert rotation (e.g. process kill + reopen)
+	# triggers a recreate. Set to false to fall back to the legacy behaviour
+	# where DTLS is never recreated on ICE restart.
+	#dtls_recreate_on_ice_restart = true
 
 	# By default Janus tries to resolve mDNS (.local) candidates: even
 	# though this is now done asynchronously and shouldn't keep the API

--- a/src/ice.c
+++ b/src/ice.c
@@ -190,8 +190,11 @@ gboolean janus_ice_is_hangup_on_failed_enabled(void) {
 /* Whether to recreate the DTLS stack on ICE restart. When a peer's process is killed
  * during an active call and reconnects via ICE restart, the existing SSL* object rejects
  * the fresh ClientHello as an RFC 5746 renegotiation, leaving DTLS stuck. Enabling this
- * destroys and recreates the DTLS stack on ICE restart so the new handshake completes. */
-static gboolean dtls_recreate_on_ice_restart = FALSE;
+ * destroys and recreates the DTLS stack on ICE restart so the new handshake completes.
+ * Default ON: the recreate path is now gated by a fingerprint-change check (see
+ * janus_ice_restart()), so plain ICE restarts with the same peer cert keep the existing
+ * stack and only true peer-cert rotations (process kill / restoration) trigger a recreate. */
+static gboolean dtls_recreate_on_ice_restart = TRUE;
 
 void janus_ice_set_dtls_recreate_on_ice_restart_enabled(gboolean enabled) {
 	dtls_recreate_on_ice_restart = enabled;


### PR DESCRIPTION
## Summary

Flip the default of `dtls_recreate_on_ice_restart` from `false` to `true`. With #12 in place the recreate path is now gated on whether the peer's `a=fingerprint` actually changed between the previous and the current remote SDP, so a plain ICE restart on the same `PeerConnection` keeps the existing `SSL*` alive and only a true peer-cert rotation triggers the recreate.

That removes the reason the flag was kept off by default and makes WT-1299 force-stop restoration work out of the box, without the regression for Wi-Fi handover that the original unconditional recreate path caused (WT-1540).

## Depends on

**#12** must merge first. Without that fingerprint-skip guard, flipping the default to `true` reintroduces the WT-1540 regression: every ICE restart (including plain Wi-Fi handover) would tear down the working DTLS stack, the peer would not initiate a new handshake against the server-side empty `SSL*`, 20s DTLS timeout, call drops.

Please do not merge this PR before #12.

## Change

- `src/ice.c` - `static gboolean dtls_recreate_on_ice_restart = TRUE;` (was `FALSE`), comment refreshed to point at the fingerprint guard added in #12.
- `conf/janus.jcfg.sample.in` - sample default flipped to `#dtls_recreate_on_ice_restart = true`, doc-comment expanded to describe the fingerprint-skip behaviour and the escape hatch to opt back to `false`.

Net: +12 / -3 across 2 files. No behaviour change for deployments that were already setting the flag to `true` explicitly, or for any code path other than the in-process default.

## Behaviour matrix after this PR + #12

| Scenario | Peer cert | dtls_recreate path | Outcome |
|---|---|---|---|
| Plain ICE restart (Wi-Fi handover, same app instance) | same | skipped via fingerprint guard (from #12) | DTLS survives, audio continues |
| Force-stop + reopen (new app instance, fresh cert) | new | recreate runs | new cert accepted, WT-1299 fixed |
| Existing deploy with explicit `dtls_recreate_on_ice_restart = false` in jcfg | n/a | flag stays off, no recreate | unchanged - legacy behaviour |

## Production impact

Deployments that did not set the option explicitly will now get the recreate path, gated by the fingerprint check. With #12 merged this is a safe upgrade and closes WT-1299 by default. Deployments that want the strict legacy behaviour can opt out by setting `dtls_recreate_on_ice_restart = false` in `janus.jcfg`.

## Test plan

- [x] Build with the default flipped, plain Wi-Fi handover: log shows `"DTLS fingerprint unchanged on ICE restart, keeping existing stack"` (from #12), no recreate, no 20s timeout, audio resumes.
- [x] Force-stop + reopen: peer cert differs, recreate runs, new handshake completes.
- [x] Regression in a deployment that explicitly sets `dtls_recreate_on_ice_restart = false` - flag should still be honoured (pure semantic flip of the default, the explicit override path is untouched).

## References

- WT-1540 - root issue, audio fails to restore after Wi-Fi handover when the flag is on without the fingerprint guard.
- WT-1299 - original reason the flag exists.
- #9 - introduced the opt-in flag.
- #12 - adds the fingerprint-change guard that makes flipping the default safe.
